### PR TITLE
Nomination reorg

### DIFF
--- a/nomination-protocol/network.ivy
+++ b/nomination-protocol/network.ivy
@@ -24,6 +24,13 @@ isolate network = {
     # because every quorum slice is contained in the set of all nodes.
     axiom is_quorum(nset.universe)
 
+    relation node_heard_quorum_accept_value(NODE:id_t, QUORUM:nset, VALUE:val_t)
+    definition node_heard_quorum_accept_value(NODE, QUORUM, VALUE) =
+       is_quorum(QUORUM) &
+       nset.member(NODE, QUORUM) &
+       (forall OTHER. nset.member(OTHER, QUORUM)
+         -> (NODE = OTHER | node(NODE).heard_accept(OTHER, VALUE)))
+
     relation is_blocking(V:id_t, B:nset)
 
     definition is_blocking(V, B) =
@@ -91,10 +98,7 @@ isolate network = {
         invariant node(NODE).have_confirmed(VALUE)
                     -> node(NODE).have_accepted(VALUE) &
                        exists QUORUM.
-                            is_quorum(QUORUM) &
-                            nset.member(NODE, QUORUM) &
-                            (forall OTHER. nset.member(OTHER, QUORUM)
-                                -> (NODE = OTHER | node(NODE).heard_accept(OTHER, VALUE)))
+                       node_heard_quorum_accept_value(NODE, QUORUM, VALUE)
 
 # IVy can't seem to prove this.
 # The setup is wrong and/or I haven't added enough invariants.

--- a/nomination-protocol/network.ivy
+++ b/nomination-protocol/network.ivy
@@ -1,42 +1,36 @@
 #lang ivy1.7
 
-include set
+isolate network = {
 
-module network(id_t, val_t) = {
+    # Network can be called src a node sending a message.
+    action broadcast_vote(src:id_t, value:val_t)
+    action broadcast_accept(src:id_t, value:val_t)
 
+    # Network can also be "called" spontaneously to note the
+    # delivery of a message at a node.
+    action deliver_vote(src:id_t, dst:id_t, value:val_t)
+    action deliver_accept(src:id_t, dst:id_t, value:val_t)
 
-    object intf = {
-        # Network can be called src a node sending a message.
-        action broadcast_vote(src:id_t, value:val_t)
-        action broadcast_accept(src:id_t, value:val_t)
+    # Adding quorums in the network module lets us not worry about quorum slices.
+    # In the actual network, each node's quorum slices are public information
+    # and the calculation of quorums from quorum slices does not depend on
+    # who does the calculation, so it seems okay to put this here.
+    relation is_quorum(S:nset)
+    relation intersect(S:nset, T:nset)
+    axiom [intersection_basic_prop] nset.member(V, S1) & nset.member(V, S2) -> intersect(S1, S2)
+    axiom [quorum_intersection] is_quorum(S1) & is_quorum(S2) -> intersect(S1, S2)
 
-        # Network can also be "called" spontaneously to note the
-        # delivery of a message at a node.
-        action deliver_vote(src:id_t, dst:id_t, value:val_t)
-        action deliver_accept(src:id_t, dst:id_t, value:val_t)
+    # The set of all nodes is a quorum
+    # because every quorum slice is contained in the set of all nodes.
+    axiom is_quorum(nset.universe)
 
-        # Adding quorums in the network module lets us not worry about quorum slices.
-        # In the actual network, each node's quorum slices are public information
-        # and the calculation of quorums from quorum slices does not depend on
-        # who does the calculation, so it seems okay to put this here.
-        instance nset : set(id_t)
-        relation is_quorum(S:nset)
-        relation intersect(S:nset, T:nset)
-        axiom [intersection_basic_prop] nset.member(V, S1) & nset.member(V, S2) -> intersect(S1, S2)
-        axiom [quorum_intersection] is_quorum(S1) & is_quorum(S2) -> intersect(S1, S2)
+    relation is_blocking(V:id_t, B:nset)
 
-        # The set of all nodes is a quorum
-        # because every quorum slice is contained in the set of all nodes.
-        axiom is_quorum(nset.universe)
+    definition is_blocking(V, B) =
+      forall QUORUM . is_quorum(QUORUM) & nset.member(V, QUORUM)
+        -> intersect(B, QUORUM)
 
-        relation is_blocking(V:id_t, B:nset)
-
-        definition is_blocking(V, B) =
-            forall QUORUM . is_quorum(QUORUM) & nset.member(V, QUORUM)
-                                -> intersect(B, QUORUM)
-    }
-
-    object spec = {
+    specification {
         relation have_broadcast_vote(SRC:id_t, VALUE:val_t)
         relation have_broadcast_accept(SRC:id_t, VALUE:val_t)
         relation have_delivered_vote(SRC:id_t, DST:id_t, VALUE:val_t)
@@ -49,68 +43,43 @@ module network(id_t, val_t) = {
             have_delivered_accept(SRC, DST, VALUE) := false;
         }
 
-        before intf.broadcast_vote {
-            require nodes(src).spec.have_voted(value);
+        before broadcast_vote {
+            require node(src).have_voted(value);
         }
-        after intf.broadcast_vote {
+        after broadcast_vote {
             have_broadcast_vote(src, value) := true;
         }
 
-        before intf.deliver_vote {
+        before deliver_vote {
             require have_broadcast_vote(src, value);
             # Remove this next condition to allow message duplication.
             require ~have_delivered_vote(src, dst, value);
         }
-        after intf.deliver_vote {
-            call nodes(dst).intf.recv_vote(src, value);
-            spec.have_delivered_vote(src, dst, value) := true;
+        after deliver_vote {
+            call node(dst).recv_vote(src, value);
+            have_delivered_vote(src, dst, value) := true;
         }
 
-        before intf.broadcast_accept {
-            require nodes(src).spec.have_accepted(value);
+        before broadcast_accept {
+            require node(src).have_accepted(value);
         }
-        after intf.broadcast_accept {
+        after broadcast_accept {
             have_broadcast_accept(src, value) := true;
         }
 
-        before intf.deliver_accept {
+        before deliver_accept {
             require have_broadcast_accept(src, value);
             # Remove this next condition to allow message duplication.
             require ~have_delivered_accept(src, dst, value);
         }
-        after intf.deliver_accept {
-            call nodes(dst).intf.recv_accept(src, value);
-            spec.have_delivered_accept(src, dst, value) := true;
+        after deliver_accept {
+            call node(dst).recv_accept(src, value);
+            have_delivered_accept(src, dst, value) := true;
         }
 
         #######
         ####### ***INVARIANT***
         #######
-
-        # Seemingly trivial invariants.
-        # For some reason, IVy seems to like to come up with CTIs that violate these,
-        # so it's probably a good idea to keep these here.
-        invariant have_broadcast_vote(NODE, VALUE) -> nodes(NODE).spec.have_voted(VALUE)
-        invariant have_delivered_vote(SRC, DST, VALUE)
-                    <-> nodes(SRC).spec.have_voted(VALUE) &
-                       nodes(DST).spec.heard_vote(SRC, VALUE) &
-                       have_broadcast_vote(SRC, VALUE)
-        invariant have_broadcast_accept(NODE, VALUE) -> nodes(NODE).spec.have_accepted(VALUE)
-        invariant nodes(ID).spec.have_accepted(VALUE) ->
-                    exists OTHER. nodes(OTHER).spec.have_voted(VALUE)
-        invariant have_delivered_accept(SRC, DST, VALUE)
-                    -> exists OTHER. nodes(OTHER).spec.have_voted(VALUE)
-        invariant have_delivered_accept(SRC, DST, VALUE)
-                    -> nodes(SRC).spec.have_accepted(VALUE)
-        invariant (SRC ~= DST & have_delivered_accept(SRC, DST, VALUE))
-                    -> nodes(DST).spec.heard_accept(SRC, VALUE)
-        invariant nodes(ID).spec.have_confirmed(VALUE) ->
-                    exists OTHER. nodes(OTHER).spec.have_voted(VALUE)
-        invariant have_delivered_accept(SRC, DST, VALUE)
-                    -> have_broadcast_accept(SRC, VALUE) & nodes(DST).spec.heard_accept(SRC, VALUE)
-        invariant (A ~= B & nodes(A).spec.heard_vote(B, VALUE))
-                    -> nodes(B).spec.have_voted(VALUE) &
-                        have_broadcast_vote(B, VALUE)
 
         # If NODE has confirmed VALUE,
         # It must be the case that NODE has accepted VALUE
@@ -119,19 +88,19 @@ module network(id_t, val_t) = {
         #     * NODE is in the quorum, and
         #     * NODE has heard from every other node in the quorum that they accepted VALUE.
         # This is just the definition of confirming from the white paper.
-        invariant nodes(NODE).spec.have_confirmed(VALUE)
-                    -> nodes(NODE).spec.have_accepted(VALUE) &
+        invariant node(NODE).have_confirmed(VALUE)
+                    -> node(NODE).have_accepted(VALUE) &
                        exists QUORUM.
-                            intf.is_quorum(QUORUM) &
-                            intf.nset.member(NODE, QUORUM) &
-                            (forall OTHER. intf.nset.member(OTHER, QUORUM)
-                                -> (NODE = OTHER | nodes(NODE).spec.heard_accept(OTHER, VALUE)))
+                            is_quorum(QUORUM) &
+                            nset.member(NODE, QUORUM) &
+                            (forall OTHER. nset.member(OTHER, QUORUM)
+                                -> (NODE = OTHER | node(NODE).heard_accept(OTHER, VALUE)))
 
 # IVy can't seem to prove this.
 # The setup is wrong and/or I haven't added enough invariants.
 #        invariant [if_confirmed_everyone_will_confirm]
-#            nodes(ID).spec.have_confirmed(VALUE)
-#                -> (forall OTHER_ID . nodes(OTHER_ID).spec.have_confirmed(VALUE)) |
+#            node(ID).have_confirmed(VALUE)
+#                -> (forall OTHER_ID . node(OTHER_ID).have_confirmed(VALUE)) |
 #                   (exists SRC, DST . have_broadcast_vote(SRC, VALUE) &
 #                                      ~have_delivered_vote(SRC, DST, VALUE)) |
 #                   (exists SRC, DST . have_broadcast_accept(SRC, VALUE) &
@@ -140,8 +109,8 @@ module network(id_t, val_t) = {
 # IVy can't seem to prove this.
 # The setup is wrong and/or I haven't added enough invariants.
 #        invariant [eventually_at_least_one_candidate_value]
-#            nodes(ID).spec.have_voted(VALUE)
-#                -> nodes(ID).spec.have_confirmed(VALUE) |
+#            node(ID).have_voted(VALUE)
+#                -> node(ID).have_confirmed(VALUE) |
 #                   (exists SRC, DST . have_broadcast_vote(SRC, VALUE) &
 #                                      ~have_delivered_vote(SRC, DST, VALUE)) |
 #                   (exists SRC, DST . have_broadcast_accept(SRC, VALUE) &
@@ -154,16 +123,40 @@ module network(id_t, val_t) = {
             (forall SRC, DST, VALUE.
                 (have_broadcast_vote(SRC, VALUE) -> have_delivered_vote(SRC, DST, VALUE)) &
                 (have_broadcast_accept(SRC, VALUE) -> have_delivered_accept(SRC, DST, VALUE)))
-            -> (forall NODE1, NODE2, VALUE. nodes(NODE1).spec.have_confirmed(VALUE) -> nodes(NODE2).spec.have_confirmed(VALUE))
+            -> (forall NODE1, NODE2, VALUE. node(NODE1).have_confirmed(VALUE) -> node(NODE2).have_confirmed(VALUE))
     }
 
-    object impl = {
-        relation something_private(X:id_t)
-        implement intf.broadcast_vote {
-            something_private(src) := true
+    implementation {
+        implement broadcast_vote {
         }
-        implement intf.deliver_vote {
-            something_private(src) := true
+        implement deliver_vote {
         }
     }
-}
+
+    private {
+        # Seemingly trivial invariants.
+        # For some reason, IVy seems to like to come up with CTIs that violate these,
+        # so it's probably a good idea to keep these here.
+        invariant have_broadcast_vote(NODE, VALUE) -> node(NODE).have_voted(VALUE)
+        invariant have_delivered_vote(SRC, DST, VALUE)
+                    <-> node(SRC).have_voted(VALUE) &
+                       node(DST).heard_vote(SRC, VALUE) &
+                       have_broadcast_vote(SRC, VALUE)
+        invariant have_broadcast_accept(NODE, VALUE) -> node(NODE).have_accepted(VALUE)
+        invariant node(ID).have_accepted(VALUE) ->
+                    exists OTHER. node(OTHER).have_voted(VALUE)
+        invariant have_delivered_accept(SRC, DST, VALUE)
+                    -> exists OTHER. node(OTHER).have_voted(VALUE)
+        invariant have_delivered_accept(SRC, DST, VALUE)
+                    -> node(SRC).have_accepted(VALUE)
+        invariant (SRC ~= DST & have_delivered_accept(SRC, DST, VALUE))
+                    -> node(DST).heard_accept(SRC, VALUE)
+        invariant node(ID).have_confirmed(VALUE) ->
+                    exists OTHER. node(OTHER).have_voted(VALUE)
+        invariant have_delivered_accept(SRC, DST, VALUE)
+                    -> have_broadcast_accept(SRC, VALUE) & node(DST).heard_accept(SRC, VALUE)
+        invariant (A ~= B & node(A).heard_vote(B, VALUE))
+                    -> node(B).have_voted(VALUE) &
+                        have_broadcast_vote(B, VALUE)
+    }
+} with node

--- a/nomination-protocol/node.ivy
+++ b/nomination-protocol/node.ivy
@@ -4,24 +4,22 @@
 # self_id is the id_t of each node instance
 # val_t is the type of values
 
-module node(id_t, self_id, val_t) = {
+isolate node(self_id:id_t) = {
 
     # Interface of a node -- only define ways node can be called here.
-    object intf = {
-        # Node can be called from application
-        # and asked to begin voting on something.
-        action vote_for(value:val_t)
+    # Node can be called from application
+    # and asked to begin voting on something.
+    action vote_for(value:val_t)
 
-        # Node can also be called from network
-        # and told that someone else voted or accepted.
-        action recv_vote(src:id_t, value:val_t)
-        action recv_accept(src:id_t, value:val_t)
-    }
+    # Node can also be called from network
+    # and told that someone else voted or accepted.
+    action recv_vote(src:id_t, value:val_t)
+    action recv_accept(src:id_t, value:val_t)
 
     # Logical specs for the interface -- use ghost variables here to track
     # logical changes to node's knowledge and state over time. These may
     # also be observed by other modules and other node instances.
-    object spec = {
+    specification {
         relation heard_vote(SRC:id_t, VALUE:val_t)
         relation heard_accept(SRC:id_t, VALUE:val_t)
 
@@ -39,88 +37,88 @@ module node(id_t, self_id, val_t) = {
             have_candidate_value := false;
         }
 
-        before intf.vote_for {
+        before vote_for {
             require ~have_voted(value);
             require ~have_candidate_value;
         }
 
-        after intf.vote_for {
+        after vote_for {
             have_voted(value) := true;
-            call net.intf.broadcast_vote(self_id, value);
+            call network.broadcast_vote(self_id, value);
         }
 
-        before intf.recv_vote {
-            require net.spec.have_delivered_vote(src, self_id, value)
+        before recv_vote {
+            require network.have_delivered_vote(src, self_id, value)
         }
 
-        after intf.recv_vote {
+        after recv_vote {
             heard_vote(src, value) := true;
 
             # Condition 1 for accepting
             if ((have_voted(value) | have_accepted(value)) &
                 (exists Q.
-                    (net.intf.is_quorum(Q) &
-                     net.intf.nset.member(self_id, Q) &
+                    (network.is_quorum(Q) &
+                     nset.member(self_id, Q) &
                      (forall OTHER.
-                        (net.intf.nset.member(OTHER, Q)
+                        (nset.member(OTHER, Q)
                          -> (heard_vote(OTHER, value) |
                              heard_accept(OTHER, value) |
                              OTHER = self_id)))))) {
                 have_accepted(value) := true;
-                call net.intf.broadcast_accept(self_id, value);
+                call network.broadcast_accept(self_id, value);
             };
 
             # Condition 2 for accepting
             if (exists B.
-                (net.intf.is_blocking(self_id, B) &
-                 (forall V. (net.intf.nset.member(V, B) -> heard_accept(V, value))))) {
+                (network.is_blocking(self_id, B) &
+                 (forall V. (nset.member(V, B) -> heard_accept(V, value))))) {
                 have_accepted(value) := true;
-                call net.intf.broadcast_accept(self_id, value);
+                call network.broadcast_accept(self_id, value);
             };
-            
+
             # Confirm
             if (have_accepted(value) &
                 (exists Q.
-                    (net.intf.is_quorum(Q) &
+                    (network.is_quorum(Q) &
                      forall OTHER.
-                        (net.intf.nset.member(OTHER, Q)
+                        (nset.member(OTHER, Q)
                             -> (self_id = OTHER | heard_accept(OTHER, value)))))) {
                 have_confirmed(value) := true;
                 have_candidate_value := true;
             };
         }
 
-        after intf.recv_accept {
+        after recv_accept {
             heard_accept(src, value) := true;
 
             # Condition 1 for accepting
             if ((have_voted(value) | have_accepted(value)) &
                 (exists Q.
-                    (net.intf.is_quorum(Q) &
-                     net.intf.nset.member(self_id, Q) &
+                    (network.is_quorum(Q) &
+                     nset.member(self_id, Q) &
                      (forall OTHER .
-                        (net.intf.nset.member(OTHER, Q)
+                        (nset.member(OTHER, Q)
                          -> (heard_vote(OTHER, value) |
                              heard_accept(OTHER, value) |
                              OTHER = self_id)))))) {
                 have_accepted(value) := true;
-                call net.intf.broadcast_accept(self_id, value);
+                call network.broadcast_accept(self_id, value);
             };
 
             # Condition 2 for accepting
             if (exists B.
-                (net.intf.is_blocking(self_id, B) &
-                 (forall V . (net.intf.nset.member(V, B) -> heard_accept(V, value))))) {
+                (network.is_blocking(self_id, B) &
+                 (forall V . (nset.member(V, B) -> heard_accept(V, value))))) {
                 have_accepted(value) := true;
-                call net.intf.broadcast_accept(self_id, value);
+                call network.broadcast_accept(self_id, value);
             };
-            
+
             # Confirm
             if (have_accepted(value) &
                 (exists Q.
-                    (net.intf.is_quorum(Q) &
+                    (network.is_quorum(Q) &
                      forall OTHER.
-                        (net.intf.nset.member(OTHER, Q)
+                        (nset.member(OTHER, Q)
                             -> (self_id = OTHER | heard_accept(OTHER, value)))))) {
                 have_confirmed(value) := true;
                 have_candidate_value := true;
@@ -131,12 +129,12 @@ module node(id_t, self_id, val_t) = {
     # Implementation of the interface matching the logical specs -- use concrete
     # variables here to implement the interface defined and spec'ed above. These
     # should not be observed outside the current node.
-    object impl = {
+    implementation {
 
         # Include any state variables that would actually show up in
         # an implementation but we don't want to include in the spec.
         # individual voted : bool
-        implement intf.vote_for {
+        implement vote_for {
         }
     }
-}
+} with network

--- a/nomination-protocol/nomination.ivy
+++ b/nomination-protocol/nomination.ivy
@@ -1,28 +1,20 @@
 #lang ivy1.7
 
+include set
+
+type id_t
+type val_t
+instance nset : set(id_t)
+
 include node
 include network
 
-# The type of node identities (eg. public keys / IP addresses or such)
-type id_t
-
-# The type of values being voted-on.
-type val_t
-
-# We have one network module for specifying network-wide properties.
-instance net : network(id_t, val_t)
-
-# And we have a _set_ of node modules, one per element of the opaque id_t type,
-# for specifying properties local to a single node. Each node gets told its own
-# identity via the second parameter ID.
-instance nodes(ID:id_t) : node(id_t, ID, val_t)
-
 # Allow IVy to cause any number of vote_for actions to initiate activities on
 # individual nodes.
-export nodes(ID).intf.vote_for
+export node(ID).vote_for
 
 # Allow Ivy to initiate messages from the network side
-export net.intf.broadcast_vote
-export net.intf.deliver_vote
-export net.intf.broadcast_accept
-export net.intf.deliver_accept
+export network.broadcast_vote
+export network.deliver_vote
+export network.broadcast_accept
+export network.deliver_accept


### PR DESCRIPTION
Two commits here:

  - First reorganizes the code based on my current best-guess understanding of the "right" way to organize modules/objects/isolates and visibility levels. It's similar to how I suggested before but after 2 weeks of chewing on documentation-writing tasks I _think_ the reorg I'm proposing here simultaneously makes it more useful (allowing isolated verification of node and network isolates) and easier to read (removing all the `.spec` and `.intf` noise everywhere).

  - Second breaks the subterm you were having trouble with (that causes a relevant-vocabulary cycle) into a separate relation, as simply / directly as possible. This seems to work. I need to continue to read and reflect / revisit notes on _exactly why_ it works, but I hope it unblocks you!